### PR TITLE
feat: disabledSettings prop to disable deep liquidity and force mint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [2.4.0] - 2026-07-08
+
+### Added
+
+- New optional `disabledSettings` prop (`{ deepLiquidity?: boolean; forceMint?: boolean }`). A disabled option renders its checkbox frozen unchecked in the zap settings panel and the corresponding behavior is forced off in quote requests.
+
 ## [2.3.6] - 2026-07-07
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ Simple mode features:
 | `debug`          | `boolean`                       | ❌       | Enable debug mode to show additional info      |
 | `defaultSource`  | `QuoteSource`                   | ❌       | Default quote source: `'best'` (compare all enabled providers), `'zap'`, `'odos'`, `'velora'`, or `'enso'` |
 | `refreshRate`    | `number`                        | ❌       | Quote refresh interval in milliseconds (defaults to `9000`) |
+| `disabledSettings` | `DisabledSettingsConfig`      | ❌       | Disable individual zap settings (`deepLiquidity`, `forceMint`); disabled options render frozen unchecked and the behavior is forced off |
 | `className`      | `string`                        | ❌       | Additional CSS classes                         |
 | `locale`         | `'en' \| 'es' \| 'ko' \| 'zh'`  | ❌       | UI language. Defaults to `'en'`; untranslated strings fall back to English |
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reserve-protocol/react-zapper",
-  "version": "2.3.6",
+  "version": "2.4.0",
   "type": "module",
   "packageManager": "pnpm@11.1.1",
   "description": "React component for DTF minting with zap functionality",

--- a/src/components/updaters.tsx
+++ b/src/components/updaters.tsx
@@ -9,6 +9,7 @@ import {
   apiUrlAtom,
   chainIdAtom,
   connectWalletAtom,
+  deepLiquidityAtom,
   DEFAULT_REFRESH_RATE,
   indexDTFAtom,
   indexDTFBasketAmountsAtom,
@@ -23,10 +24,17 @@ import {
   walletAtom,
   zapperApiUrlAtom,
 } from '../state/atoms'
-import { DEFAULT_API_URL, ScheduleCallConfig, Token } from '../types'
+import {
+  DEFAULT_API_URL,
+  DisabledSettingsConfig,
+  ScheduleCallConfig,
+  Token,
+} from '../types'
 import TokenBalancesUpdater from './updaters/token-balances-updater'
 import SessionTracker from './updaters/session-tracker'
 import {
+  disabledSettingsAtom,
+  forceMintAtom,
   scheduleCallAtom,
   sellOnlyAtom,
   showContactInfoAtom,
@@ -52,6 +60,7 @@ interface UpdatersProps {
   sellOnly?: boolean
   showContactInfo?: boolean
   scheduleCall?: ScheduleCallConfig
+  disabledSettings?: DisabledSettingsConfig
   refreshRate?: number
 }
 
@@ -280,6 +289,28 @@ const ScheduleCallUpdater = ({
   return null
 }
 
+const DisabledSettingsUpdater = ({
+  disabledSettings,
+}: {
+  disabledSettings?: DisabledSettingsConfig
+}) => {
+  const setDisabledSettings = useSetAtom(disabledSettingsAtom)
+  const setDeepLiquidity = useSetAtom(deepLiquidityAtom)
+  const setForceMint = useSetAtom(forceMintAtom)
+
+  useEffect(() => {
+    setDisabledSettings(disabledSettings)
+    if (disabledSettings?.deepLiquidity) {
+      setDeepLiquidity(false)
+    }
+    if (disabledSettings?.forceMint) {
+      setForceMint(false)
+    }
+  }, [disabledSettings, setDisabledSettings, setDeepLiquidity, setForceMint])
+
+  return null
+}
+
 const Updaters: React.FC<UpdatersProps> = ({
   dtfAddress,
   chainId,
@@ -292,6 +323,7 @@ const Updaters: React.FC<UpdatersProps> = ({
   sellOnly,
   showContactInfo,
   scheduleCall,
+  disabledSettings,
   refreshRate,
 }) => {
   return (
@@ -309,6 +341,7 @@ const Updaters: React.FC<UpdatersProps> = ({
       <SellOnlyUpdater sellOnly={sellOnly} />
       <ContactInfoUpdater showContactInfo={showContactInfo} />
       <ScheduleCallUpdater scheduleCall={scheduleCall} />
+      <DisabledSettingsUpdater disabledSettings={disabledSettings} />
       <RefreshRateUpdater refreshRate={refreshRate} />
       <SessionTracker mode={mode} />
     </>

--- a/src/components/zap-mint/atom.ts
+++ b/src/components/zap-mint/atom.ts
@@ -2,7 +2,12 @@ import { atom } from 'jotai'
 import { atomWithReset } from 'jotai/utils'
 import type { UseQuoteResult } from '../../hooks/useQuote'
 import { balancesAtom, chainIdAtom, indexDTFAtom } from '../../state/atoms'
-import { ScheduleCallConfig, Token, TokenBalance } from '../../types'
+import {
+  DisabledSettingsConfig,
+  ScheduleCallConfig,
+  Token,
+  TokenBalance,
+} from '../../types'
 import { reducedZappableTokens } from '../../utils/constants'
 
 const openZapMintModalBaseAtom = atom(false)
@@ -21,6 +26,9 @@ export const sellOnlyAtom = atom<boolean>(false)
 export const openingFromSimpleModeAtom = atom<boolean>(false)
 export const showContactInfoAtom = atom<boolean>(true)
 export const scheduleCallAtom = atom<ScheduleCallConfig | undefined>(undefined)
+export const disabledSettingsAtom = atom<DisabledSettingsConfig | undefined>(
+  undefined
+)
 
 // Snapshot of the last successful zap; drives the success view. Captured at
 // confirmation so the view survives the Buy/Sell form unmounting.

--- a/src/components/zap-mint/zap-settings.tsx
+++ b/src/components/zap-mint/zap-settings.tsx
@@ -19,7 +19,7 @@ import {
   SelectValue,
 } from '../ui/select'
 import { SlippageSelector } from '../ui/swap'
-import { forceMintAtom, slippageAtom } from './atom'
+import { disabledSettingsAtom, forceMintAtom, slippageAtom } from './atom'
 
 const ZapSettingsRowTitle = ({
   title,
@@ -41,6 +41,7 @@ const ZapSettings = () => {
   const [forceMint, setForceMint] = useAtom(forceMintAtom)
   const [quoteSource, setQuoteSource] = useAtom(quoteSourceAtom)
   const [deepLiquidity, setDeepLiquidity] = useAtom(deepLiquidityAtom)
+  const disabledSettings = useAtomValue(disabledSettingsAtom)
 
   const handleSlippageChange = (value: string) => {
     setSlippage(value)
@@ -116,6 +117,7 @@ const ZapSettings = () => {
           <Checkbox
             checked={deepLiquidity}
             onCheckedChange={handleDeepLiquidityChange}
+            disabled={disabledSettings?.deepLiquidity}
           />
         </div>
       </div>
@@ -132,6 +134,7 @@ const ZapSettings = () => {
           <Checkbox
             checked={forceMint}
             onCheckedChange={handleForceMintChange}
+            disabled={disabledSettings?.forceMint}
           />
         </div>
       </div>

--- a/src/components/zapper.tsx
+++ b/src/components/zapper.tsx
@@ -272,6 +272,7 @@ export const Zapper: React.FC<ZapperProps> = ({
   disabled,
   showContactInfo,
   scheduleCall,
+  disabledSettings,
   locale,
   refreshRate,
 }) => {
@@ -289,6 +290,7 @@ export const Zapper: React.FC<ZapperProps> = ({
         sellOnly={sellOnly}
         showContactInfo={showContactInfo}
         scheduleCall={scheduleCall}
+        disabledSettings={disabledSettings}
         refreshRate={refreshRate}
       />
       <ZapperContent mode={mode} sellOnly={sellOnly} disabled={disabled} />

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,4 +28,5 @@ export type {
   UseZapperModalReturn,
   Token,
   TokenBalance,
+  DisabledSettingsConfig,
 } from './types'

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -28,6 +28,13 @@ export interface ScheduleCallConfig {
   onSchedule?: () => void
 }
 
+export interface DisabledSettingsConfig {
+  /** Freeze the "Deep liquidity search" checkbox unchecked and force the behavior off. */
+  deepLiquidity?: boolean
+  /** Freeze the "Force minting DTF" checkbox unchecked and force the behavior off. */
+  forceMint?: boolean
+}
+
 export interface ZapperProps {
   mode?: 'modal' | 'inline' | 'simple'
   chain: AvailableChain
@@ -43,6 +50,8 @@ export interface ZapperProps {
   showContactInfo?: boolean
   /** Offer a "schedule an intro call" panel after a large purchase. Omit to disable. */
   scheduleCall?: ScheduleCallConfig
+  /** Disable individual zap settings. Disabled options render frozen unchecked. */
+  disabledSettings?: DisabledSettingsConfig
   /** UI language. Defaults to 'en'. Falls back to English for any untranslated string. */
   locale?: SupportedLocale
   /** Quote refresh interval in milliseconds. Defaults to 9000. */


### PR DESCRIPTION
  Adds an optional `disabledSettings` prop (`{ deepLiquidity?, forceMint? }`).
  A disabled option renders its checkbox frozen unchecked in the zap settings
  panel and the behavior is forced off in quote requests.

  Releases 2.4.0.