### PR TITLE
fix: hide disabled zap settings, remove dust row, portal tooltips

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+## [2.4.2] - 2026-07-08
+
+### Changed
+
+- Options disabled via `disabledSettings` are now hidden from the zap settings panel instead of rendered as frozen unchecked checkboxes.
+
+### Removed
+
+- "Send dust back to wallet" row from the zap settings panel. Dust is always collected; behavior is unchanged.
+
+### Fixed
+
+- Help tooltips no longer get clipped by the dialog edge — tooltip content now renders in a portal.
+
 ## [2.4.1] - 2026-07-08
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reserve-protocol/react-zapper",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "type": "module",
   "packageManager": "pnpm@11.1.1",
   "description": "React component for DTF minting with zap functionality",

--- a/src/components/ui/tooltip.tsx
+++ b/src/components/ui/tooltip.tsx
@@ -13,15 +13,17 @@ const TooltipContent = React.forwardRef<
   React.ElementRef<typeof TooltipPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof TooltipPrimitive.Content>
 >(({ className, sideOffset = 4, ...props }, ref) => (
-  <TooltipPrimitive.Content
-    ref={ref}
-    sideOffset={sideOffset}
-    className={cn(
-      "z-50 overflow-hidden rounded-md border bg-popover px-3 py-1.5 text-sm text-popover-foreground shadow-md animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
-      className
-    )}
-    {...props}
-  />
+  <TooltipPrimitive.Portal>
+    <TooltipPrimitive.Content
+      ref={ref}
+      sideOffset={sideOffset}
+      className={cn(
+        "z-50 overflow-hidden rounded-md border bg-popover px-3 py-1.5 text-sm text-popover-foreground shadow-md animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        className
+      )}
+      {...props}
+    />
+  </TooltipPrimitive.Portal>
 ))
 TooltipContent.displayName = TooltipPrimitive.Content.displayName
 

--- a/src/components/zap-mint/zap-settings.tsx
+++ b/src/components/zap-mint/zap-settings.tsx
@@ -1,7 +1,6 @@
-import { broom } from '@lucide/lab'
 import { Trans, useLingui } from '@lingui/react/macro'
 import { useAtom, useAtomValue } from 'jotai'
-import { Anvil, Icon, Route, Search } from 'lucide-react'
+import { Anvil, Route, Search } from 'lucide-react'
 import {
   chainIdAtom,
   deepLiquidityAtom,
@@ -104,57 +103,42 @@ const ZapSettings = () => {
           hideTitle
         />
       </div>
-      <div className="flex flex-col gap-2">
-        <ZapSettingsRowTitle
-          title={t`Enable Deep liquidity search?`}
-          help={t`Can improve price impact but it will take more time to get quotes.`}
-        />
-        <div className="rounded-xl border border-border px-3 py-3 flex items-center gap-1 justify-between">
-          <div className="flex items-center gap-1">
-            <Search size={16} className="text-muted-foreground" />
-            <div><Trans>Deep liquidity search</Trans></div>
-          </div>
-          <Checkbox
-            checked={deepLiquidity}
-            onCheckedChange={handleDeepLiquidityChange}
-            disabled={disabledSettings?.deepLiquidity}
+      {!disabledSettings?.deepLiquidity && (
+        <div className="flex flex-col gap-2">
+          <ZapSettingsRowTitle
+            title={t`Enable Deep liquidity search?`}
+            help={t`Can improve price impact but it will take more time to get quotes.`}
           />
-        </div>
-      </div>
-      <div className="flex flex-col gap-2">
-        <ZapSettingsRowTitle
-          title={t`Force DTF mint?`}
-          help={t`This is useful if you want to mint the DTF without trading.`}
-        />
-        <div className="rounded-xl border border-border px-3 py-3 flex items-center gap-1 justify-between">
-          <div className="flex items-center gap-1">
-            <Anvil size={16} className="text-muted-foreground" />
-            <div><Trans>Force minting DTF</Trans></div>
-          </div>
-          <Checkbox
-            checked={forceMint}
-            onCheckedChange={handleForceMintChange}
-            disabled={disabledSettings?.forceMint}
-          />
-        </div>
-      </div>
-      <div className="flex flex-col gap-2">
-        <ZapSettingsRowTitle
-          title={t`Collect dust?`}
-          help={t`Dust is the leftover amount of tokens that cannot be exchanged. If you choose to collect dust, it will be sent back to your wallet. Sending dust back to the wallet will increase transaction fee.`}
-        />
-        <div className="rounded-xl border border-border px-3 py-3 flex items-center gap-1 justify-between">
-          <div className="flex items-center gap-1">
-            <Icon
-              iconNode={broom}
-              size={16}
-              className="text-muted-foreground"
+          <div className="rounded-xl border border-border px-3 py-3 flex items-center gap-1 justify-between">
+            <div className="flex items-center gap-1">
+              <Search size={16} className="text-muted-foreground" />
+              <div><Trans>Deep liquidity search</Trans></div>
+            </div>
+            <Checkbox
+              checked={deepLiquidity}
+              onCheckedChange={handleDeepLiquidityChange}
             />
-            <div><Trans>Send dust back to wallet</Trans></div>
           </div>
-          <Checkbox checked disabled />
         </div>
-      </div>
+      )}
+      {!disabledSettings?.forceMint && (
+        <div className="flex flex-col gap-2">
+          <ZapSettingsRowTitle
+            title={t`Force DTF mint?`}
+            help={t`This is useful if you want to mint the DTF without trading.`}
+          />
+          <div className="rounded-xl border border-border px-3 py-3 flex items-center gap-1 justify-between">
+            <div className="flex items-center gap-1">
+              <Anvil size={16} className="text-muted-foreground" />
+              <div><Trans>Force minting DTF</Trans></div>
+            </div>
+            <Checkbox
+              checked={forceMint}
+              onCheckedChange={handleForceMintChange}
+            />
+          </div>
+        </div>
+      )}
     </div>
   )
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -29,9 +29,9 @@ export interface ScheduleCallConfig {
 }
 
 export interface DisabledSettingsConfig {
-  /** Freeze the "Deep liquidity search" checkbox unchecked and force the behavior off. */
+  /** Hide the "Deep liquidity search" setting and force the behavior off. */
   deepLiquidity?: boolean
-  /** Freeze the "Force minting DTF" checkbox unchecked and force the behavior off. */
+  /** Hide the "Force minting DTF" setting and force the behavior off. */
   forceMint?: boolean
 }
 
@@ -50,7 +50,7 @@ export interface ZapperProps {
   showContactInfo?: boolean
   /** Offer a "schedule an intro call" panel after a large purchase. Omit to disable. */
   scheduleCall?: ScheduleCallConfig
-  /** Disable individual zap settings. Disabled options render frozen unchecked. */
+  /** Disable individual zap settings. Disabled options are hidden from the settings panel. */
   disabledSettings?: DisabledSettingsConfig
   /** UI language. Defaults to 'en'. Falls back to English for any untranslated string. */
   locale?: SupportedLocale


### PR DESCRIPTION
## What

  Releases `2.4.2` with three changes to the zap settings panel:

  - **`disabledSettings` now hides instead of disables.** Options flagged via the
    `disabledSettings` prop (`deepLiquidity`, `forceMint`) no longer render as frozen
    unchecked checkboxes — the rows are removed from the settings panel entirely.
    The behavior is still forced off in quote requests, and the prop API is unchanged,
    so consumers already passing `disabledSettings` get the new behavior with no code
    changes.
  - **"Send dust back to wallet" row removed for all DTFs.** The checkbox was
    hardcoded checked-and-disabled, so this is purely visual — dust is still always
    collected.
  - **Fixed tooltip clipping inside the dialog.** `TooltipContent` wasn't wrapped in
    `TooltipPrimitive.Portal`, so help tooltips rendered inside the dialog's
    `overflow-y-auto` container and got cut off at the modal edge. Content now portals
    to the body (same pattern the Select in the panel already uses), fixing every help
    tooltip in the modal.

  ## Notes

  - Version bumped `2.4.1` → `2.4.2`, changelog updated. Rebased on top of the
    `2.4.1` release.
  - The removed strings remain as stale entries in the compiled locale catalogs
    (`src/locales/*.po`); harmless, cleaned up on the next `lingui extract`.
  - Verified by linking into register: locked DTFs show only Quote Source + slippage,
    regular DTFs keep both toggles, tooltips render fully.
