### PR TITLE
fix: seed zapper chain synchronously to avoid wrong-chain first-render query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## [2.6.0] - 2026-07-13
+
+### Fixed
+
+- Cross-chain navigation no longer fires a wrong-chain request on first render. `ChainIdUpdater` synced its `chain` prop into the widget's internal chain atom in an effect that lagged the first render, so the DTF and basket updaters briefly queried the default (mainnet) subgraph/price endpoint for a Base/BSC DTF before the prop applied. The chain is now seeded synchronously during render, so the first read already targets the correct chain.
+
+### Changed
+
+- Upgraded `jotai` from v1 to v2 (`^2.19.1`). No changes to the public component API.
+
 ## [2.5.1] - 2026-07-08
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reserve-protocol/react-zapper",
-  "version": "2.5.1",
+  "version": "2.6.0",
   "type": "module",
   "packageManager": "pnpm@11.1.1",
   "description": "React component for DTF minting with zap functionality",
@@ -67,7 +67,7 @@
     "@radix-ui/react-tooltip": "^1.2.7",
     "clsx": "^2.1.1",
     "decimal.js-light": "^2.5.1",
-    "jotai": "^1.12.0",
+    "jotai": "^2.19.1",
     "lucide-react": "^0.461.0",
     "mixpanel-browser": "^2.56.0",
     "tailwind-merge": "^2.5.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,8 +48,8 @@ importers:
         specifier: ^2.5.1
         version: 2.5.1
       jotai:
-        specifier: ^1.12.0
-        version: 1.13.1(@babel/core@7.29.0)(@babel/template@7.28.6)(react@18.3.1)
+        specifier: ^2.19.1
+        version: 2.20.1(@babel/core@7.29.0)(@babel/template@7.28.6)(@types/react@18.3.28)(react@18.3.1)
       lucide-react:
         specifier: ^0.461.0
         version: 0.461.0(react@18.3.1)
@@ -3699,44 +3699,22 @@ packages:
   jose@6.2.3:
     resolution: {integrity: sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==}
 
-  jotai@1.13.1:
-    resolution: {integrity: sha512-RUmH1S4vLsG3V6fbGlKzGJnLrDcC/HNb5gH2AeA9DzuJknoVxSGvvg8OBB7lke+gDc4oXmdVsaKn/xDUhWZ0vw==}
+  jotai@2.20.1:
+    resolution: {integrity: sha512-dnuKfU/GLi8B28RRMjQ3AfoN7kfzP8o41+AX2FmITZqEMY8PHnjABq+VkEooomLwYaGjda+pgy0yFSjaHX/ZPg==}
     engines: {node: '>=12.20.0'}
     peerDependencies:
-      '@babel/core': '*'
-      '@babel/template': '*'
-      jotai-devtools: '*'
-      jotai-immer: '*'
-      jotai-optics: '*'
-      jotai-redux: '*'
-      jotai-tanstack-query: '*'
-      jotai-urql: '*'
-      jotai-valtio: '*'
-      jotai-xstate: '*'
-      jotai-zustand: '*'
-      react: '>=16.8'
+      '@babel/core': '>=7.0.0'
+      '@babel/template': '>=7.0.0'
+      '@types/react': '>=17.0.0'
+      react: '>=17.0.0'
     peerDependenciesMeta:
       '@babel/core':
         optional: true
       '@babel/template':
         optional: true
-      jotai-devtools:
+      '@types/react':
         optional: true
-      jotai-immer:
-        optional: true
-      jotai-optics:
-        optional: true
-      jotai-redux:
-        optional: true
-      jotai-tanstack-query:
-        optional: true
-      jotai-urql:
-        optional: true
-      jotai-valtio:
-        optional: true
-      jotai-xstate:
-        optional: true
-      jotai-zustand:
+      react:
         optional: true
 
   js-sha256@0.10.1:
@@ -10017,12 +9995,12 @@ snapshots:
 
   jose@6.2.3: {}
 
-  jotai@1.13.1(@babel/core@7.29.0)(@babel/template@7.28.6)(react@18.3.1):
-    dependencies:
-      react: 18.3.1
+  jotai@2.20.1(@babel/core@7.29.0)(@babel/template@7.28.6)(@types/react@18.3.28)(react@18.3.1):
     optionalDependencies:
       '@babel/core': 7.29.0
       '@babel/template': 7.28.6
+      '@types/react': 18.3.28
+      react: 18.3.1
 
   js-sha256@0.10.1: {}
 

--- a/src/components/updaters.tsx
+++ b/src/components/updaters.tsx
@@ -1,6 +1,6 @@
 import { AvailableChain } from '@/utils/chains'
 import { useQuery } from '@tanstack/react-query'
-import { useAtomValue, useSetAtom } from 'jotai'
+import { useAtomValue, useSetAtom, useStore } from 'jotai'
 import React, { useEffect } from 'react'
 import { useAccount } from 'wagmi'
 import { useIndexBasket } from '../hooks/use-index-basket'
@@ -160,11 +160,13 @@ const ApiUrlUpdater = ({ apiUrl, zapperApiUrl }: { apiUrl?: string; zapperApiUrl
 }
 
 const ChainIdUpdater: React.FC<{ chainId: AvailableChain }> = ({ chainId }) => {
-  const setChainId = useSetAtom(chainIdAtom)
+  const store = useStore()
 
-  useEffect(() => {
-    setChainId(chainId)
-  }, [chainId, setChainId])
+  // Seed synchronously (not in an effect) so the DTF/basket updaters read this
+  // chain on their first render, not a wrong-chain query against mainnet.
+  if (store.get(chainIdAtom) !== chainId) {
+    store.set(chainIdAtom, chainId)
+  }
 
   return null
 }

--- a/tests/helpers/harness.tsx
+++ b/tests/helpers/harness.tsx
@@ -6,7 +6,7 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { connect } from 'wagmi/actions'
-import { Provider as JotaiProvider, useAtomValue } from 'jotai'
+import { createStore, Provider as JotaiProvider, useAtomValue } from 'jotai'
 import { createServer, type Server } from 'node:http'
 import React from 'react'
 import { ethAddress } from 'viem'
@@ -410,18 +410,17 @@ export const setup = async ({
   const queryClient = new QueryClient()
   lastQueryClient = queryClient
 
+  const store = createStore()
+  store.set(chainIdAtom, 1)
+  store.set(walletAtom, ACCOUNT)
+  store.set(indexDTFAtom, dtf)
+  store.set(quoteSourceAtom, quoteSource)
+  store.set(balancesAtom, { [ethAddress]: ethBalance })
+
   const utils = render(
     <WagmiProvider config={config} reconnectOnMount={false}>
       <QueryClientProvider client={queryClient}>
-        <JotaiProvider
-          initialValues={[
-            [chainIdAtom, 1],
-            [walletAtom, ACCOUNT],
-            [indexDTFAtom, dtf],
-            [quoteSourceAtom, quoteSource],
-            [balancesAtom, { [ethAddress]: ethBalance }],
-          ] as const}
-        >
+        <JotaiProvider store={store}>
           <ZapperI18nProvider>
             <Probe />
             <Buy mode="modal" />


### PR DESCRIPTION
## Summary

Cross-chain navigation fired a wrong-chain request on the widget's first render. `ChainIdUpdater` synced its `chain` prop into the internal chain atom in a `useEffect` that runs *after* the first render, while `chainIdAtom` inits to mainnet — so `IndexDTFMetadataUpdater`/`IndexDTFBasketUpdater` fired `getDTF` (and the price/brand reads) against the default mainnet subgraph for a Base/BSC DTF before the prop applied. The stale query self-healed a render later, but it hit the wrong chain's host in the meantime.

## Change

- `ChainIdUpdater` seeds `chainIdAtom` **synchronously during render** (it's a sibling rendered before the consumers, so they read the correct chain on their first render — covers both cold load and warm cross-chain nav).
- Upgraded `jotai` v1 → v2 for `useStore`. No public component API changes.
- Migrated the test harness from the removed jotai `Provider initialValues` API to `createStore`.

## Testing

- All 30 component tests pass.
- Verified in a downstream integration suite: cross-chain navigation now records zero wrong-chain subgraph/price requests (was one per fresh Base/BSC route load).