### PR TITLE
fix: never serve or submit an expired quote

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [2.6.1] - 2026-07-17
+
+### Fixed
+
+- Expired quotes can no longer be submitted. Some quotes carry short-lived signed calldata (BSC Ondo GM attestations live ~15s), and sending one past its `validUntil` is a guaranteed on-chain revert surfaced as an opaque "Unknown" error. The submit handler now checks `validUntil` at send time and refetches a fresh quote instead of handing dead calldata to the wallet.
+- The quote query no longer re-serves a previously cached quote when the swap parameters change back to an earlier value (or the widget remounts). The cached quote appeared instantly with the submit button armed while its calldata was already expired; a fresh quote is now always fetched.
+
 ## [2.6.0] - 2026-07-13
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reserve-protocol/react-zapper",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "type": "module",
   "packageManager": "pnpm@11.1.1",
   "description": "React component for DTF minting with zap functionality",

--- a/src/components/zap-mint/submit-zap.tsx
+++ b/src/components/zap-mint/submit-zap.tsx
@@ -290,6 +290,12 @@ const SubmitZapButton = ({
 
   const execute = useCallback(() => {
     if (!tx || !readyToSubmit) return
+    // expired calldata is a guaranteed revert — refetch instead of sending
+    if (validUntil != null && Date.now() >= validUntil) {
+      setOngoingTx(false)
+      refetchQuote.fn?.()
+      return
+    }
     setInputAmountCached(inputAmount)
     sendTransaction({
       data: tx.data as Hex,
@@ -301,6 +307,9 @@ const SubmitZapButton = ({
   }, [
     tx,
     readyToSubmit,
+    validUntil,
+    setOngoingTx,
+    refetchQuote,
     setInputAmountCached,
     inputAmount,
     sendTransaction,

--- a/src/hooks/useZapSwapQuery.ts
+++ b/src/hooks/useZapSwapQuery.ts
@@ -241,6 +241,8 @@ const useZapSwapQuery = ({
     refetchInterval: refreshRate,
     retry: 3,
     retryDelay: (attempt) => Math.min(1000 * Math.pow(2, attempt), 10000),
+    // quotes carry short-lived signed calldata — never re-serve an old one
+    gcTime: 0,
   })
 }
 

--- a/tests/expired-quote.test.tsx
+++ b/tests/expired-quote.test.tsx
@@ -1,0 +1,83 @@
+/**
+ * Invariant: a quote past its validUntil is never handed to the wallet, and
+ * the query cache never re-serves an old quote when params flip back.
+ */
+import { fireEvent, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import {
+  getCta,
+  harnessAfterEach,
+  harnessBeforeEach,
+  scenario,
+  setup,
+  waitForReadyCta,
+} from './helpers/harness'
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms))
+
+const armedCta = () => {
+  const cta = getCta()
+  return !cta.disabled && /Buy TEST/i.test(cta.textContent || '')
+}
+
+describe('expired quote invariant', () => {
+  beforeEach(async () => {
+    await harnessBeforeEach()
+  })
+
+  afterEach(async () => {
+    await harnessAfterEach()
+  })
+
+  it('never sends an expired quote — the click refetches instead', async () => {
+    scenario.quoteTtlMs = -1_000
+    await setup()
+    await waitForReadyCta()
+    const fetchesBefore = scenario.quoteFetches
+
+    fireEvent.click(getCta())
+    await sleep(1_000)
+
+    expect(
+      scenario.calls.filter((c) => c === 'eth_sendTransaction')
+    ).toHaveLength(0)
+    // the wallet was never engaged, so no tx error can have surfaced
+    expect(
+      Array.from(document.querySelectorAll('[class*="text-red"]')).some((el) =>
+        el.textContent?.trim()
+      )
+    ).toBe(false)
+    // the guard triggered an immediate replacement — the 9s tick is not due
+    await waitFor(() =>
+      expect(scenario.quoteFetches).toBeGreaterThan(fetchesBefore)
+    )
+  })
+
+  it('does not re-arm a cached quote when the amount flips back', async () => {
+    scenario.quoteTtlMs = 60_000
+    await setup()
+    await waitForReadyCta()
+
+    const input = document.querySelector('input')!
+    const fetchesBefore = scenario.quoteFetches
+
+    // slow responses so the in-flight window is observable
+    scenario.quoteDelayMs = 3_000
+    fireEvent.change(input, { target: { value: '2' } })
+    await sleep(700) // past the 500ms input debounce
+    fireEvent.change(input, { target: { value: '1' } })
+
+    // the old '1' quote must not re-arm from cache while the refetch runs
+    const until = Date.now() + 1_500
+    while (Date.now() < until) {
+      expect(armedCta()).toBe(false)
+      await sleep(50)
+    }
+
+    await waitFor(
+      () => expect(scenario.quoteFetches).toBeGreaterThan(fetchesBefore),
+      { timeout: 10_000 }
+    )
+  })
+})


### PR DESCRIPTION
## Problem

  Some quotes carry short-lived signed calldata — on BSC, DTFs with Ondo GM tokenized stock baskets embed attestations that expire ~15s after the quote is built. Submitting past `validUntil` is a guaranteed on-chain revert (`AttestationExpired`), surfaced
  to the user as an opaque "Unknown" execution error.

  Two ways a dead quote could reach the wallet:

  - Nothing checked `validUntil` at send time, so a quote that expired between arming and clicking (or while the wallet was open after an approval) was still sent.
  - The quote query cache re-served an old quote instantly when the swap params flipped back to a previous value (or the widget remounted), arming the submit button with already-expired calldata while the background refetch was still running.

  Diagnosed from a production failure on the NEOCLOUD DTF (BSC): the reverting tx carried attestations from a quote ~30s older than the attempt.

  ## Fix

  - `execute()` checks `validUntil` before sending — an expired quote drops the click and refetches instead of engaging the wallet.
  - `gcTime: 0` on the quote query — old quotes are never re-served from cache; a fresh quote is always fetched.

  ## Tests

  New `tests/expired-quote.test.tsx` pins the invariant with two tests (never sends expired, never re-arms from cache). Both fail on `main` and pass with this change; the existing recovery/spiral suites are untouched and still pass.

  Bumps version to 2.6.1