### PR TITLE
demo: live quote table for every Index DTF

### DIFF
--- a/README.md
+++ b/README.md
@@ -488,8 +488,13 @@ latency and a link to the raw quote URL.
   queued a few requests at a time so a cycle never fans out one request per DTF
   at once.
 - The **input side is configured per chain** (amount + token from
-  `zappableTokens`) since the supported inputs differ; quotes use a placeholder
-  signer, so no wallet is needed.
+  `zappableTokens`) since the supported inputs differ.
+- **Wallet is optional.** Without one, quotes use `PLACEHOLDER_SIGNER` and are
+  display-only. Connect one and every row is quoted for that signer — so the
+  response carries a real transaction and gas — and each transaction is
+  simulated with `estimateGas`, giving a Simulation column of `ok` / `reverts` /
+  the reason it couldn't be proven (`approval needed`, `insufficient balance`,
+  RPC noise). Nothing is ever submitted from this page.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -494,7 +494,11 @@ latency and a link to the raw quote URL.
   response carries a real transaction and gas — and each transaction is
   simulated with `estimateGas`, giving a Simulation column of `ok` / `reverts` /
   the reason it couldn't be proven (`approval needed`, `insufficient balance`,
-  RPC noise). Nothing is ever submitted from this page.
+  RPC noise). The only transaction this page ever sends is an approval:
+  "Create approvals" under the input selector approves each chain's input token
+  for that chain's zapper spender (`ZapResult.approvalAddress`, so a chain must
+  have quoted once), one transaction per chain, at the widget's `amountIn * 1.2`.
+  Zaps themselves are never submitted here — use the widget page for that.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -495,9 +495,10 @@ latency and a link to the raw quote URL.
   simulated with `estimateGas`, giving a Simulation column of `ok` / `reverts` /
   the reason it couldn't be proven (`approval needed`, `insufficient balance`,
   RPC noise). The only transaction this page ever sends is an approval:
-  "Create approvals" under the input selector approves each chain's input token
-  for that chain's zapper spender (`ZapResult.approvalAddress`, so a chain must
-  have quoted once), one transaction per chain, at the widget's `amountIn * 1.2`.
+  "Create approvals" under the input selector approves every configured input
+  token for that chain's zapper spender (`ZapResult.approvalAddress`, so a chain
+  must have quoted once), one transaction per chain, at the widget's
+  `amountIn * 1.2`.
   Zaps themselves are never submitted here — use the widget page for that.
 
 ## License

--- a/README.md
+++ b/README.md
@@ -471,6 +471,26 @@ pnpm dev
 
 Visit `http://localhost:5173` to see the demo.
 
+### Quote Table
+
+`http://localhost:5173/quotes.html` (`/quotes.html` in the deployed demo) is a
+second page for watching quotes across the whole DTF universe instead of one DTF
+at a time: every Index DTF from the Reserve API's discover endpoint, one row
+each, with output amount, USD value, price impact, true price impact, dust,
+latency and a link to the raw quote URL.
+
+- Only the **native zap provider** is quoted (the endpoint selector picks which
+  zapper service answers — Default, ZRS-1/2/3 or local). Aggregator and RFQ
+  sources are deliberately not requested: they don't exercise the zapper, and a
+  full source comparison per DTF per interval hits their rate limits.
+- **Auto-refresh is off on load** and nothing is quoted until "Refresh now" is
+  pressed; the dropdown next to it starts a 15s / 60s / 300s cadence. Rounds are
+  queued a few requests at a time so a cycle never fans out one request per DTF
+  at once.
+- The **input side is configured per chain** (amount + token from
+  `zappableTokens`) since the supported inputs differ; quotes use a placeholder
+  signer, so no wallet is needed.
+
 ## License
 
 MIT License - see LICENSE file for details.

--- a/demo/App.tsx
+++ b/demo/App.tsx
@@ -119,6 +119,9 @@ function App() {
             </p>
           </div>
           <div className="flex items-center gap-3">
+            <Button variant="outline" asChild>
+              <a href="/quotes.html">Quote table</a>
+            </Button>
             <Button
               variant="outline"
               size="icon"

--- a/demo/QuotesApp.tsx
+++ b/demo/QuotesApp.tsx
@@ -1,5 +1,7 @@
 import { useEffect, useMemo, useState } from 'react'
+import { ConnectButton } from '@rainbow-me/rainbowkit'
 import { Moon, RefreshCw, Sun } from 'lucide-react'
+import { useAccount } from 'wagmi'
 import { zappableTokens } from '@reserve-protocol/react-zapper'
 import { AvailableChain, CHAIN_TAGS, ChainId } from '@/utils/chains'
 import { usePrice } from '@/hooks/usePrice'
@@ -92,6 +94,10 @@ function QuotesApp() {
     includeDeprecated,
   })
 
+  // Connecting a wallet upgrades every row from a display-only quote to a real
+  // signer's quote plus a simulation of its transaction.
+  const { address } = useAccount()
+
   // One price per chain — the input side of every row on that chain. The DTF
   // side is priced from the discover payload.
   const mainnetPrice = usePrice(
@@ -142,6 +148,7 @@ function QuotesApp() {
             </p>
           </div>
           <div className="flex items-center gap-3">
+            <ConnectButton showBalance={false} />
             <Button variant="outline" asChild>
               <a href="/">Zapper demo</a>
             </Button>
@@ -166,7 +173,10 @@ function QuotesApp() {
               <CardTitle className="text-lg">Configuration</CardTitle>
               <CardDescription>
                 Quotes come from the native zap provider only — aggregator and
-                RFQ sources are not requested
+                RFQ sources are not requested.{' '}
+                {address
+                  ? 'Quoted for the connected wallet and simulated.'
+                  : 'Connect a wallet to quote for a real signer and simulate each row.'}
               </CardDescription>
             </CardHeader>
             <CardContent className="space-y-4">
@@ -418,6 +428,7 @@ function QuotesApp() {
                   slippage={slippage}
                   forceMint={forceMint}
                   deepLiquidity={deepLiquidity}
+                  account={address}
                   round={round}
                   armed={armed}
                   autoRefreshMs={autoRefreshMs > 0 ? autoRefreshMs : null}

--- a/demo/QuotesApp.tsx
+++ b/demo/QuotesApp.tsx
@@ -1,0 +1,434 @@
+import { useEffect, useMemo, useState } from 'react'
+import { Moon, RefreshCw, Sun } from 'lucide-react'
+import { zappableTokens } from '@reserve-protocol/react-zapper'
+import { AvailableChain, CHAIN_TAGS, ChainId } from '@/utils/chains'
+import { usePrice } from '@/hooks/usePrice'
+import { Button } from './components/ui/button'
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from './components/ui/card'
+import { Input } from './components/ui/input'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from './components/ui/select'
+import QuotesTable, { ChainInput } from './components/quotes-table'
+import { useDiscoverDTFs } from './lib/dtf-discover'
+
+const API_URLS = [
+  { label: 'Default', value: 'https://api.reserve.org/' },
+  { label: 'Staging', value: 'https://api-staging.reserve.org/' },
+  { label: 'Local', value: 'http://localhost:3005/' },
+]
+
+// Only the native zap provider is quoted here, so every option is a zapper
+// service: the table exists to watch what the ZRS instances answer.
+const ZAPPER_API_URLS = [
+  { label: 'Default', value: 'https://api.reserve.org/' },
+  { label: 'ZRS-1', value: 'https://zrs-1.reserve-api.com/' },
+  { label: 'ZRS-2', value: 'https://zrs-2.reserve-api.com/' },
+  { label: 'ZRS-3', value: 'https://zrs-3.reserve-api.com/' },
+  { label: 'Local', value: 'http://localhost:3005/' },
+]
+
+// Reserve slippage convention: a value S means a fraction of 1/S.
+const SLIPPAGE_OPTIONS = [
+  { label: '0.1%', value: 1000 },
+  { label: '0.5%', value: 200 },
+  { label: '1%', value: 100 },
+  { label: '3%', value: 33 },
+]
+
+// Auto-refresh is off until the user picks a cadence — a quote round costs one
+// zapper request per DTF, so nothing repeats behind their back.
+const REFRESH_OPTIONS = [
+  { label: 'Off', value: 0 },
+  { label: '15 seconds', value: 15_000 },
+  { label: '60 seconds', value: 60_000 },
+  { label: '300 seconds', value: 300_000 },
+]
+
+const CHAINS: AvailableChain[] = [ChainId.Mainnet, ChainId.Base, ChainId.BSC]
+
+const defaultInputs = (): Record<number, ChainInput> =>
+  Object.fromEntries(
+    CHAINS.map((chainId) => [
+      chainId,
+      // Stables lead every zappable list, so this is the chain's stable input.
+      { token: zappableTokens[chainId][0], amount: '1000' },
+    ])
+  )
+
+function QuotesApp() {
+  const [apiUrl, setApiUrl] = useState(API_URLS[0].value)
+  const [zapperApiUrl, setZapperApiUrl] = useState(ZAPPER_API_URLS[1].value)
+  const [slippage, setSlippage] = useState(SLIPPAGE_OPTIONS[1].value)
+  const [forceMint, setForceMint] = useState(false)
+  const [deepLiquidity, setDeepLiquidity] = useState(false)
+  const [includeDeprecated, setIncludeDeprecated] = useState(false)
+  const [inputs, setInputs] = useState<Record<number, ChainInput>>(defaultInputs)
+  const [autoRefreshMs, setAutoRefreshMs] = useState(0)
+  const [round, setRound] = useState(0)
+  const [armed, setArmed] = useState(false)
+  const [dark, setDark] = useState<boolean>(() => {
+    const stored = localStorage.getItem('theme')
+    if (stored) return stored === 'dark'
+    return window.matchMedia('(prefers-color-scheme: dark)').matches
+  })
+
+  useEffect(() => {
+    document.documentElement.classList.toggle('dark', dark)
+    localStorage.setItem('theme', dark ? 'dark' : 'light')
+  }, [dark])
+
+  const { data: dtfs, isLoading, error } = useDiscoverDTFs(apiUrl, {
+    includeDeprecated,
+  })
+
+  // One price per chain — the input side of every row on that chain. The DTF
+  // side is priced from the discover payload.
+  const mainnetPrice = usePrice(
+    ChainId.Mainnet,
+    inputs[ChainId.Mainnet].token.address,
+    apiUrl
+  )
+  const basePrice = usePrice(
+    ChainId.Base,
+    inputs[ChainId.Base].token.address,
+    apiUrl
+  )
+  const bscPrice = usePrice(
+    ChainId.BSC,
+    inputs[ChainId.BSC].token.address,
+    apiUrl
+  )
+  const prices = useMemo(
+    () => ({
+      [ChainId.Mainnet]: mainnetPrice,
+      [ChainId.Base]: basePrice,
+      [ChainId.BSC]: bscPrice,
+    }),
+    [mainnetPrice, basePrice, bscPrice]
+  )
+
+  const refreshNow = () => {
+    setArmed(true)
+    setRound((n) => n + 1)
+  }
+
+  const startAutoRefresh = (value: number) => {
+    setAutoRefreshMs(value)
+    if (value > 0) refreshNow()
+  }
+
+  return (
+    <div className="min-h-screen bg-background">
+      <div className="container mx-auto max-w-[1600px] p-6">
+        <div className="mb-8 flex items-center justify-between">
+          <div>
+            <h1 className="text-3xl font-bold text-foreground">
+              React Zapper Quote Table
+            </h1>
+            <p className="mt-1 text-muted-foreground">
+              Live mint quotes for every Index DTF, from the same zapper the
+              widget calls
+            </p>
+          </div>
+          <div className="flex items-center gap-3">
+            <Button variant="outline" asChild>
+              <a href="/">Zapper demo</a>
+            </Button>
+            <Button
+              variant="outline"
+              size="icon"
+              onClick={() => setDark((d) => !d)}
+              aria-label="Toggle theme"
+            >
+              {dark ? (
+                <Sun className="h-4 w-4" />
+              ) : (
+                <Moon className="h-4 w-4" />
+              )}
+            </Button>
+          </div>
+        </div>
+
+        <div className="grid grid-cols-1 gap-6 lg:grid-cols-4">
+          <Card className="h-fit border-border-secondary bg-secondary/30">
+            <CardHeader>
+              <CardTitle className="text-lg">Configuration</CardTitle>
+              <CardDescription>
+                Quotes come from the native zap provider only — aggregator and
+                RFQ sources are not requested
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div>
+                <label className="mb-2 block text-sm font-medium">
+                  Zapper API Endpoint
+                </label>
+                <Select value={zapperApiUrl} onValueChange={setZapperApiUrl}>
+                  <SelectTrigger className="w-full">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {ZAPPER_API_URLS.map((url) => (
+                      <SelectItem key={url.value} value={url.value}>
+                        {url.label} - {url.value}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+                <p className="mt-1 text-xs text-muted-foreground">
+                  Zapper service quoted for every row
+                </p>
+              </div>
+              <div>
+                <label className="mb-2 block text-sm font-medium">
+                  API Endpoint
+                </label>
+                <Select value={apiUrl} onValueChange={setApiUrl}>
+                  <SelectTrigger className="w-full">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {API_URLS.map((url) => (
+                      <SelectItem key={url.value} value={url.value}>
+                        {url.label} - {url.value}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+                <p className="mt-1 text-xs text-muted-foreground">
+                  Reserve API endpoint (DTF list, prices)
+                </p>
+              </div>
+              <div>
+                <label className="mb-2 block text-sm font-medium">
+                  Slippage
+                </label>
+                <Select
+                  value={slippage.toString()}
+                  onValueChange={(value) => setSlippage(Number(value))}
+                >
+                  <SelectTrigger className="w-full">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {SLIPPAGE_OPTIONS.map((option) => (
+                      <SelectItem
+                        key={option.value}
+                        value={option.value.toString()}
+                      >
+                        {option.label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+              <div>
+                <label className="mb-2 block text-sm font-medium">
+                  Force Mint
+                </label>
+                <Select
+                  value={forceMint.toString()}
+                  onValueChange={(value) => setForceMint(value === 'true')}
+                >
+                  <SelectTrigger className="w-full">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {[false, true].map((v) => (
+                      <SelectItem key={v.toString()} value={v.toString()}>
+                        {v.toString()}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+                <p className="mt-1 text-xs text-muted-foreground">
+                  Mints the basket instead of trading into it (
+                  <code>trade=false</code>)
+                </p>
+              </div>
+              <div>
+                <label className="mb-2 block text-sm font-medium">
+                  Deep Liquidity
+                </label>
+                <Select
+                  value={deepLiquidity.toString()}
+                  onValueChange={(value) => setDeepLiquidity(value === 'true')}
+                >
+                  <SelectTrigger className="w-full">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {[false, true].map((v) => (
+                      <SelectItem key={v.toString()} value={v.toString()}>
+                        {v.toString()}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+              <div>
+                <label className="mb-2 block text-sm font-medium">
+                  Include Deprecated DTFs
+                </label>
+                <Select
+                  value={includeDeprecated.toString()}
+                  onValueChange={(value) =>
+                    setIncludeDeprecated(value === 'true')
+                  }
+                >
+                  <SelectTrigger className="w-full">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {[false, true].map((v) => (
+                      <SelectItem key={v.toString()} value={v.toString()}>
+                        {v.toString()}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+
+              <div className="space-y-3 border-t border-border-secondary pt-4">
+                <p className="text-sm font-medium">Input per chain</p>
+                {CHAINS.map((chainId) => (
+                  <div key={chainId} className="space-y-2">
+                    <label className="block text-xs text-muted-foreground">
+                      {CHAIN_TAGS[chainId]}
+                    </label>
+                    <div className="flex gap-2">
+                      <Input
+                        value={inputs[chainId].amount}
+                        inputMode="decimal"
+                        onChange={(event) =>
+                          setInputs((current) => ({
+                            ...current,
+                            [chainId]: {
+                              ...current[chainId],
+                              amount: event.target.value,
+                            },
+                          }))
+                        }
+                      />
+                      <Select
+                        value={inputs[chainId].token.address}
+                        onValueChange={(value) =>
+                          setInputs((current) => ({
+                            ...current,
+                            [chainId]: {
+                              ...current[chainId],
+                              token: zappableTokens[chainId].find(
+                                (token) => token.address === value
+                              )!,
+                            },
+                          }))
+                        }
+                      >
+                        <SelectTrigger className="w-32">
+                          <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent>
+                          {zappableTokens[chainId].map((token) => (
+                            <SelectItem
+                              key={token.address}
+                              value={token.address}
+                            >
+                              {token.symbol}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </CardContent>
+          </Card>
+
+          <Card className="lg:col-span-3">
+            <CardHeader className="flex flex-row items-start justify-between gap-4">
+              <div className="space-y-1.5">
+                <CardTitle className="flex items-center gap-2">
+                  <span
+                    className={`h-2 w-2 rounded-full ${
+                      autoRefreshMs > 0 ? 'animate-pulse bg-primary' : 'bg-muted'
+                    }`}
+                  />
+                  Quotes ({dtfs?.length ?? 0} DTFs)
+                </CardTitle>
+                <CardDescription>
+                  {autoRefreshMs > 0
+                    ? `Refreshing every ${autoRefreshMs / 1000}s`
+                    : 'Auto-refresh off'}
+                </CardDescription>
+              </div>
+              <div className="flex items-center gap-2">
+                <Button onClick={refreshNow}>
+                  <RefreshCw className="mr-2 h-4 w-4" />
+                  Refresh now
+                </Button>
+                <Select
+                  value={autoRefreshMs.toString()}
+                  onValueChange={(value) => startAutoRefresh(Number(value))}
+                >
+                  <SelectTrigger className="w-40">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {REFRESH_OPTIONS.map((option) => (
+                      <SelectItem
+                        key={option.value}
+                        value={option.value.toString()}
+                      >
+                        {option.value === 0
+                          ? 'Auto-refresh off'
+                          : `Every ${option.label}`}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+            </CardHeader>
+            <CardContent className="px-0">
+              {isLoading ? (
+                <p className="px-6 text-muted-foreground">Loading DTFs…</p>
+              ) : error ? (
+                <p className="px-6 text-destructive">
+                  {error instanceof Error
+                    ? error.message
+                    : 'Failed to load DTFs'}
+                </p>
+              ) : (
+                <QuotesTable
+                  dtfs={dtfs ?? []}
+                  inputs={inputs}
+                  prices={prices}
+                  zapperApiUrl={zapperApiUrl}
+                  slippage={slippage}
+                  forceMint={forceMint}
+                  deepLiquidity={deepLiquidity}
+                  round={round}
+                  armed={armed}
+                  autoRefreshMs={autoRefreshMs > 0 ? autoRefreshMs : null}
+                />
+              )}
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default QuotesApp

--- a/demo/QuotesApp.tsx
+++ b/demo/QuotesApp.tsx
@@ -1,4 +1,5 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { Address } from 'viem'
 import { ConnectButton } from '@rainbow-me/rainbowkit'
 import { Moon, RefreshCw, Sun } from 'lucide-react'
 import { useAccount } from 'wagmi'
@@ -21,6 +22,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from './components/ui/select'
+import ApproveInputs from './components/approve-inputs'
 import QuotesTable, { ChainInput } from './components/quotes-table'
 import { useDiscoverDTFs } from './lib/dtf-discover'
 
@@ -78,6 +80,9 @@ function QuotesApp() {
   const [inputs, setInputs] = useState<Record<number, ChainInput>>(defaultInputs)
   const [autoRefreshMs, setAutoRefreshMs] = useState(0)
   const [round, setRound] = useState(0)
+  const [approvalTargets, setApprovalTargets] = useState<
+    Record<number, Address | undefined>
+  >({})
   const [armed, setArmed] = useState(false)
   const [dark, setDark] = useState<boolean>(() => {
     const stored = localStorage.getItem('theme')
@@ -97,6 +102,16 @@ function QuotesApp() {
   // Connecting a wallet upgrades every row from a display-only quote to a real
   // signer's quote plus a simulation of its transaction.
   const { address } = useAccount()
+
+  const onApprovalTarget = useCallback(
+    (chainId: number, approvalAddress: Address) =>
+      setApprovalTargets((current) =>
+        current[chainId] === approvalAddress
+          ? current
+          : { ...current, [chainId]: approvalAddress }
+      ),
+    []
+  )
 
   // One price per chain — the input side of every row on that chain. The DTF
   // side is priced from the discover payload.
@@ -362,6 +377,11 @@ function QuotesApp() {
                     </div>
                   </div>
                 ))}
+                <ApproveInputs
+                  chains={CHAINS}
+                  inputs={inputs}
+                  approvalTargets={approvalTargets}
+                />
               </div>
             </CardContent>
           </Card>
@@ -429,6 +449,7 @@ function QuotesApp() {
                   forceMint={forceMint}
                   deepLiquidity={deepLiquidity}
                   account={address}
+                  onApprovalTarget={onApprovalTarget}
                   round={round}
                   armed={armed}
                   autoRefreshMs={autoRefreshMs > 0 ? autoRefreshMs : null}

--- a/demo/components/approve-inputs.tsx
+++ b/demo/components/approve-inputs.tsx
@@ -1,13 +1,7 @@
 import { useQueryClient } from '@tanstack/react-query'
 import { useState } from 'react'
 import { Address, erc20Abi, parseUnits } from 'viem'
-import {
-  useAccount,
-  useConfig,
-  useReadContracts,
-  useSwitchChain,
-  useWriteContract,
-} from 'wagmi'
+import { useAccount, useConfig, useSwitchChain, useWriteContract } from 'wagmi'
 import { waitForTransactionReceipt } from 'wagmi/actions'
 import { AvailableChain, CHAIN_TAGS } from '@/utils/chains'
 import { Button } from './ui/button'
@@ -18,8 +12,8 @@ type ApproveInputsProps = {
   inputs: Record<number, ChainInput>
   /**
    * Zapper spender per chain, as reported by that chain's quotes
-   * (`ZapResult.approvalAddress`) — a chain can't be approved before it has
-   * quoted at least once.
+   * (`ZapResult.approvalAddress`) — it isn't a constant anywhere in the
+   * package, so a chain can't be approved before it has quoted once.
    */
   approvalTargets: Record<number, Address | undefined>
 }
@@ -27,7 +21,9 @@ type ApproveInputsProps = {
 /**
  * Simulation is the reason this exists: an unapproved input makes every row on
  * that chain unverifiable, so the inputs are approved once, for the whole
- * table, instead of per row.
+ * table, instead of per row. Every configured input is approved — re-approving
+ * an already-approved token is harmless, and checking allowances first would
+ * only trade a redundant transaction for extra state.
  */
 const ApproveInputs = ({
   chains,
@@ -42,57 +38,31 @@ const ApproveInputs = ({
   const [busy, setBusy] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
-  // The widget approves 20% above the quoted input; matching it means a small
-  // amount bump doesn't demand a new approval.
-  const required = (chainId: number) => {
-    const input = inputs[chainId]
-    if (!input || !(Number(input.amount) > 0)) return null
-    return (parseUnits(input.amount, input.token.decimals) * 120n) / 100n
-  }
-
-  // Only the chains whose spender is known can be read; the rest simply stay
-  // out of the allowance query (and out of `missing`).
-  const readable = address
-    ? chains.filter((chainId) => !!approvalTargets[chainId])
-    : []
-
-  const { data: allowances, refetch: refetchAllowances } = useReadContracts({
-    allowFailure: false,
-    contracts: readable.map((chainId) => ({
-      chainId,
-      abi: erc20Abi,
-      address: inputs[chainId].token.address,
-      functionName: 'allowance' as const,
-      args: [address!, approvalTargets[chainId]!] as const,
-    })),
-  })
-
-  const missing = readable.filter((chainId, index) => {
-    const needed = required(chainId)
-    if (needed == null) return false
-    const allowance = allowances?.[index]
-    return allowance == null || allowance < needed
-  })
+  const pending = chains.filter(
+    (chainId) => approvalTargets[chainId] && Number(inputs[chainId].amount) > 0
+  )
 
   const approveAll = async () => {
     setBusy(true)
     setError(null)
     try {
-      for (const chainId of missing) {
-        const target = approvalTargets[chainId]
-        const needed = required(chainId)
-        if (!target || needed == null) continue
+      for (const chainId of pending) {
+        const { token, amount } = inputs[chainId]
         if (connectedChain !== chainId) await switchChainAsync({ chainId })
         const hash = await writeContractAsync({
           chainId,
           abi: erc20Abi,
-          address: inputs[chainId].token.address,
+          address: token.address,
           functionName: 'approve',
-          args: [target, needed],
+          // The widget approves 20% above the quoted input; matching it means a
+          // small amount bump doesn't demand a new approval.
+          args: [
+            approvalTargets[chainId]!,
+            (parseUnits(amount, token.decimals) * 120n) / 100n,
+          ],
         })
         await waitForTransactionReceipt(config, { hash, chainId })
       }
-      await refetchAllowances()
       // Re-quote so the simulation column moves off "approval needed".
       await queryClient.invalidateQueries({ queryKey: ['dtf-zap-quote'] })
     } catch (e) {
@@ -109,21 +79,20 @@ const ApproveInputs = ({
       <Button
         variant="outline"
         className="w-full"
-        disabled={busy || missing.length === 0}
+        disabled={busy || pending.length === 0}
         onClick={approveAll}
       >
-        {busy
-          ? 'Approving…'
-          : missing.length === 0
-            ? 'Inputs approved'
-            : `Create approvals (${missing.length})`}
+        {busy ? 'Approving…' : `Create approvals (${pending.length})`}
       </Button>
       <p className="text-xs text-muted-foreground">
-        {missing.length === 0
-          ? 'Every chain input is approved for the zapper.'
-          : `Needs approval: ${missing
-              .map((chainId) => `${CHAIN_TAGS[chainId]} ${inputs[chainId].token.symbol}`)
-              .join(', ')}. One transaction per chain.`}
+        {pending.length === 0
+          ? 'Quote once so the zapper reports its spender for each chain.'
+          : `Approves ${pending
+              .map(
+                (chainId) =>
+                  `${CHAIN_TAGS[chainId]} ${inputs[chainId].token.symbol}`
+              )
+              .join(', ')} — one transaction per chain.`}
       </p>
       {error && <p className="text-xs text-destructive">{error}</p>}
     </div>

--- a/demo/components/approve-inputs.tsx
+++ b/demo/components/approve-inputs.tsx
@@ -1,0 +1,133 @@
+import { useQueryClient } from '@tanstack/react-query'
+import { useState } from 'react'
+import { Address, erc20Abi, parseUnits } from 'viem'
+import {
+  useAccount,
+  useConfig,
+  useReadContracts,
+  useSwitchChain,
+  useWriteContract,
+} from 'wagmi'
+import { waitForTransactionReceipt } from 'wagmi/actions'
+import { AvailableChain, CHAIN_TAGS } from '@/utils/chains'
+import { Button } from './ui/button'
+import { ChainInput } from './quotes-table'
+
+type ApproveInputsProps = {
+  chains: AvailableChain[]
+  inputs: Record<number, ChainInput>
+  /**
+   * Zapper spender per chain, as reported by that chain's quotes
+   * (`ZapResult.approvalAddress`) — a chain can't be approved before it has
+   * quoted at least once.
+   */
+  approvalTargets: Record<number, Address | undefined>
+}
+
+/**
+ * Simulation is the reason this exists: an unapproved input makes every row on
+ * that chain unverifiable, so the inputs are approved once, for the whole
+ * table, instead of per row.
+ */
+const ApproveInputs = ({
+  chains,
+  inputs,
+  approvalTargets,
+}: ApproveInputsProps) => {
+  const { address, chainId: connectedChain } = useAccount()
+  const config = useConfig()
+  const queryClient = useQueryClient()
+  const { switchChainAsync } = useSwitchChain()
+  const { writeContractAsync } = useWriteContract()
+  const [busy, setBusy] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  // The widget approves 20% above the quoted input; matching it means a small
+  // amount bump doesn't demand a new approval.
+  const required = (chainId: number) => {
+    const input = inputs[chainId]
+    if (!input || !(Number(input.amount) > 0)) return null
+    return (parseUnits(input.amount, input.token.decimals) * 120n) / 100n
+  }
+
+  // Only the chains whose spender is known can be read; the rest simply stay
+  // out of the allowance query (and out of `missing`).
+  const readable = address
+    ? chains.filter((chainId) => !!approvalTargets[chainId])
+    : []
+
+  const { data: allowances, refetch: refetchAllowances } = useReadContracts({
+    allowFailure: false,
+    contracts: readable.map((chainId) => ({
+      chainId,
+      abi: erc20Abi,
+      address: inputs[chainId].token.address,
+      functionName: 'allowance' as const,
+      args: [address!, approvalTargets[chainId]!] as const,
+    })),
+  })
+
+  const missing = readable.filter((chainId, index) => {
+    const needed = required(chainId)
+    if (needed == null) return false
+    const allowance = allowances?.[index]
+    return allowance == null || allowance < needed
+  })
+
+  const approveAll = async () => {
+    setBusy(true)
+    setError(null)
+    try {
+      for (const chainId of missing) {
+        const target = approvalTargets[chainId]
+        const needed = required(chainId)
+        if (!target || needed == null) continue
+        if (connectedChain !== chainId) await switchChainAsync({ chainId })
+        const hash = await writeContractAsync({
+          chainId,
+          abi: erc20Abi,
+          address: inputs[chainId].token.address,
+          functionName: 'approve',
+          args: [target, needed],
+        })
+        await waitForTransactionReceipt(config, { hash, chainId })
+      }
+      await refetchAllowances()
+      // Re-quote so the simulation column moves off "approval needed".
+      await queryClient.invalidateQueries({ queryKey: ['dtf-zap-quote'] })
+    } catch (e) {
+      setError(e instanceof Error ? e.message.split('\n')[0] : String(e))
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  if (!address) return null
+
+  return (
+    <div className="space-y-2">
+      <Button
+        variant="outline"
+        className="w-full"
+        disabled={busy || missing.length === 0}
+        onClick={approveAll}
+      >
+        {busy
+          ? 'Approving…'
+          : missing.length === 0
+            ? 'Inputs approved'
+            : `Create approvals (${missing.length})`}
+      </Button>
+      <p className="text-xs text-muted-foreground">
+        {missing.length === 0
+          ? 'Every chain input is approved for the zapper.'
+          : `Needs approval: ${missing
+              .map((chainId) => `${CHAIN_TAGS[chainId]} ${inputs[chainId].token.symbol}`)
+              .join(', ')}. One transaction per chain.`}
+      </p>
+      {error && <p className="text-xs text-destructive">{error}</p>}
+    </div>
+  )
+}
+
+export default ApproveInputs

--- a/demo/components/quotes-table.tsx
+++ b/demo/components/quotes-table.tsx
@@ -1,6 +1,8 @@
 import { useQuery } from '@tanstack/react-query'
 import React from 'react'
-import { formatUnits, parseUnits } from 'viem'
+import { Address, formatUnits, Hex, parseUnits } from 'viem'
+import { useConfig } from 'wagmi'
+import { estimateGas } from 'wagmi/actions'
 import { CHAIN_TAGS } from '@/utils/chains'
 import {
   formatCurrency,
@@ -8,12 +10,15 @@ import {
   formatToSignificantDigits,
 } from '@/utils/format'
 import { Token } from '@/types'
+import { PLACEHOLDER_SIGNER } from '@/utils/constants'
 import { DiscoverDTF } from '../lib/dtf-discover'
 import {
   buildZapEndpoint,
   DTF_DECIMALS,
   fetchZapQuote,
   QuoteRequest,
+  Simulation,
+  SimulateTx,
 } from '../lib/zap-quote'
 import {
   Table,
@@ -38,6 +43,11 @@ export type QuotesTableProps = {
   forceMint: boolean
   deepLiquidity: boolean
   /**
+   * Connected wallet, when there is one: quotes are then signed for a real
+   * account and each row's transaction is simulated.
+   */
+  account?: Address
+  /**
    * Bumped by "Refresh now": part of every row's query key, so a click always
    * fetches a new round instead of re-serving the last one.
    */
@@ -45,6 +55,29 @@ export type QuotesTableProps = {
   /** Rows stay idle until the first refresh — nothing is quoted on page load. */
   armed: boolean
   autoRefreshMs: number | null
+}
+
+const SimulationCell = ({
+  simulation,
+}: {
+  simulation: Simulation | null
+}) => {
+  if (!simulation) {
+    return <span className="text-muted-foreground">no wallet</span>
+  }
+  if (simulation.status === 'ok') return <span className="text-success">ok</span>
+  if (simulation.status === 'reverted') {
+    return (
+      <span className="text-destructive" title={simulation.error}>
+        reverts
+      </span>
+    )
+  }
+  return (
+    <span className="text-muted-foreground" title={simulation.reason}>
+      {simulation.reason}
+    </span>
+  )
 }
 
 const impactClass = (value: number) =>
@@ -74,6 +107,7 @@ const QuoteRow = ({
   slippage,
   forceMint,
   deepLiquidity,
+  account,
   round,
   armed,
   autoRefreshMs,
@@ -101,8 +135,23 @@ const QuoteRow = ({
           slippage,
           forceMint,
           deepLiquidity,
+          signer: account ?? PLACEHOLDER_SIGNER,
         }
       : null
+
+  const config = useConfig()
+  // Pure revert check: chainId and account are explicit so wagmi uses the
+  // public client for the DTF's chain and never prompts the wallet.
+  const simulate: SimulateTx | undefined = account
+    ? (tx) =>
+        estimateGas(config, {
+          chainId: dtf.chainId as (typeof config)['chains'][number]['id'],
+          account,
+          to: tx.to,
+          data: tx.data as Hex,
+          value: BigInt(tx.value || 0),
+        }).then(() => undefined)
+    : undefined
 
   const query = useQuery({
     queryKey: [
@@ -115,9 +164,10 @@ const QuoteRow = ({
       forceMint,
       deepLiquidity,
       zapperApiUrl,
+      account,
       round,
     ],
-    queryFn: () => fetchZapQuote(request!),
+    queryFn: () => fetchZapQuote(request!, simulate),
     enabled: armed && !!request,
     refetchInterval: autoRefreshMs ?? false,
     retry: false,
@@ -143,16 +193,16 @@ const QuoteRow = ({
         {input ? `${input.amount} ${input.token.symbol}` : '–'}
       </TableCell>
       {!armed ? (
-        <TableCell colSpan={6} className="text-muted-foreground">
+        <TableCell colSpan={8} className="text-muted-foreground">
           Idle — hit Refresh now to quote
         </TableCell>
       ) : query.isPending ? (
-        <TableCell colSpan={6} className="text-muted-foreground">
+        <TableCell colSpan={8} className="text-muted-foreground">
           Quoting…
         </TableCell>
       ) : query.error ? (
         <TableCell
-          colSpan={6}
+          colSpan={8}
           className="max-w-md truncate text-destructive"
           title={
             query.error instanceof Error ? query.error.message : undefined
@@ -183,6 +233,12 @@ const QuoteRow = ({
             {result!.dustValue != null
               ? `$${formatCurrency(result!.dustValue)}`
               : '–'}
+          </TableCell>
+          <TableCell>
+            <SimulationCell simulation={query.data!.simulation} />
+          </TableCell>
+          <TableCell className="text-muted-foreground">
+            {result!.gas ? formatCurrency(Number(result!.gas), 0) : '–'}
           </TableCell>
           <TableCell className="text-muted-foreground">
             {query.data!.durationMs}ms
@@ -220,6 +276,8 @@ const QuotesTable = ({ dtfs, inputs, prices, ...rowProps }: QuotesTableProps) =>
         <TableHead>Price impact</TableHead>
         <TableHead>True price impact</TableHead>
         <TableHead>Dust</TableHead>
+        <TableHead>Simulation</TableHead>
+        <TableHead>Gas</TableHead>
         <TableHead>Latency</TableHead>
         <TableHead>Updated</TableHead>
         <TableHead>Quote</TableHead>

--- a/demo/components/quotes-table.tsx
+++ b/demo/components/quotes-table.tsx
@@ -1,0 +1,242 @@
+import { useQuery } from '@tanstack/react-query'
+import React from 'react'
+import { formatUnits, parseUnits } from 'viem'
+import { CHAIN_TAGS } from '@/utils/chains'
+import {
+  formatCurrency,
+  formatPercentage,
+  formatToSignificantDigits,
+} from '@/utils/format'
+import { Token } from '@/types'
+import { DiscoverDTF } from '../lib/dtf-discover'
+import {
+  buildZapEndpoint,
+  DTF_DECIMALS,
+  fetchZapQuote,
+  QuoteRequest,
+} from '../lib/zap-quote'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from './ui/table'
+
+export type ChainInput = {
+  token: Token
+  amount: string
+}
+
+export type QuotesTableProps = {
+  dtfs: DiscoverDTF[]
+  inputs: Record<number, ChainInput>
+  prices: Record<number, number | null>
+  zapperApiUrl: string
+  slippage: number
+  forceMint: boolean
+  deepLiquidity: boolean
+  /**
+   * Bumped by "Refresh now": part of every row's query key, so a click always
+   * fetches a new round instead of re-serving the last one.
+   */
+  round: number
+  /** Rows stay idle until the first refresh — nothing is quoted on page load. */
+  armed: boolean
+  autoRefreshMs: number | null
+}
+
+const impactClass = (value: number) =>
+  value > 3
+    ? 'text-destructive'
+    : value > 1
+      ? 'text-warning'
+      : 'text-foreground'
+
+const Age = ({ updatedAt }: { updatedAt: number }) => {
+  const [, forceRender] = React.useState(0)
+
+  React.useEffect(() => {
+    const interval = setInterval(() => forceRender((n) => n + 1), 1000)
+    return () => clearInterval(interval)
+  }, [])
+
+  if (!updatedAt) return <span className="text-muted-foreground">–</span>
+  return <span>{Math.round((Date.now() - updatedAt) / 1000)}s ago</span>
+}
+
+const QuoteRow = ({
+  dtf,
+  input,
+  tokenInPrice,
+  zapperApiUrl,
+  slippage,
+  forceMint,
+  deepLiquidity,
+  round,
+  armed,
+  autoRefreshMs,
+}: Omit<QuotesTableProps, 'dtfs' | 'inputs' | 'prices'> & {
+  dtf: DiscoverDTF
+  input?: ChainInput
+  tokenInPrice: number | null
+}) => {
+  const amountIn =
+    input && Number(input.amount) > 0
+      ? parseUnits(input.amount, input.token.decimals).toString()
+      : null
+
+  const request: QuoteRequest | null =
+    input && amountIn
+      ? {
+          zapperApiUrl,
+          chainId: dtf.chainId,
+          tokenIn: input.token.address,
+          tokenInDecimals: input.token.decimals,
+          tokenInPrice,
+          amountIn,
+          tokenOut: dtf.address,
+          tokenOutPrice: dtf.price ?? null,
+          slippage,
+          forceMint,
+          deepLiquidity,
+        }
+      : null
+
+  const query = useQuery({
+    queryKey: [
+      'dtf-zap-quote',
+      dtf.chainId,
+      dtf.address,
+      input?.token.address,
+      amountIn,
+      slippage,
+      forceMint,
+      deepLiquidity,
+      zapperApiUrl,
+      round,
+    ],
+    queryFn: () => fetchZapQuote(request!),
+    enabled: armed && !!request,
+    refetchInterval: autoRefreshMs ?? false,
+    retry: false,
+    // quotes are short-lived: never re-serve a previous round's numbers
+    gcTime: 0,
+  })
+
+  const result = query.data?.result
+
+  return (
+    <TableRow>
+      <TableCell className="font-medium">
+        <span>{dtf.symbol}</span>
+        <span className="ml-2 text-xs text-muted-foreground">{dtf.name}</span>
+        {dtf.status !== 'active' && (
+          <span className="ml-2 text-xs text-warning">{dtf.status}</span>
+        )}
+      </TableCell>
+      <TableCell className="text-muted-foreground">
+        {CHAIN_TAGS[dtf.chainId]}
+      </TableCell>
+      <TableCell>
+        {input ? `${input.amount} ${input.token.symbol}` : '–'}
+      </TableCell>
+      {!armed ? (
+        <TableCell colSpan={6} className="text-muted-foreground">
+          Idle — hit Refresh now to quote
+        </TableCell>
+      ) : query.isPending ? (
+        <TableCell colSpan={6} className="text-muted-foreground">
+          Quoting…
+        </TableCell>
+      ) : query.error ? (
+        <TableCell
+          colSpan={6}
+          className="max-w-md truncate text-destructive"
+          title={
+            query.error instanceof Error ? query.error.message : undefined
+          }
+        >
+          {query.error instanceof Error ? query.error.message : 'Quote failed'}
+        </TableCell>
+      ) : (
+        <>
+          <TableCell>
+            {formatToSignificantDigits(
+              Number(formatUnits(BigInt(result!.amountOut), DTF_DECIMALS))
+            )}{' '}
+            <span className="text-xs text-muted-foreground">{dtf.symbol}</span>
+          </TableCell>
+          <TableCell>
+            {result!.amountOutValue != null
+              ? `$${formatCurrency(result!.amountOutValue)}`
+              : '–'}
+          </TableCell>
+          <TableCell className={impactClass(result!.priceImpact)}>
+            {formatPercentage(result!.priceImpact)}
+          </TableCell>
+          <TableCell className={impactClass(result!.truePriceImpact)}>
+            {formatPercentage(result!.truePriceImpact)}
+          </TableCell>
+          <TableCell>
+            {result!.dustValue != null
+              ? `$${formatCurrency(result!.dustValue)}`
+              : '–'}
+          </TableCell>
+          <TableCell className="text-muted-foreground">
+            {query.data!.durationMs}ms
+          </TableCell>
+        </>
+      )}
+      <TableCell className="text-muted-foreground">
+        {armed && !query.isPending ? <Age updatedAt={query.dataUpdatedAt} /> : '–'}
+      </TableCell>
+      <TableCell>
+        {request && (
+          <a
+            className="text-primary underline-offset-4 hover:underline"
+            href={buildZapEndpoint(request)}
+            target="_blank"
+            rel="noreferrer"
+          >
+            raw
+          </a>
+        )}
+      </TableCell>
+    </TableRow>
+  )
+}
+
+const QuotesTable = ({ dtfs, inputs, prices, ...rowProps }: QuotesTableProps) => (
+  <Table>
+    <TableHeader>
+      <TableRow>
+        <TableHead>DTF</TableHead>
+        <TableHead>Chain</TableHead>
+        <TableHead>Input</TableHead>
+        <TableHead>Output</TableHead>
+        <TableHead>Output value</TableHead>
+        <TableHead>Price impact</TableHead>
+        <TableHead>True price impact</TableHead>
+        <TableHead>Dust</TableHead>
+        <TableHead>Latency</TableHead>
+        <TableHead>Updated</TableHead>
+        <TableHead>Quote</TableHead>
+      </TableRow>
+    </TableHeader>
+    <TableBody>
+      {dtfs.map((dtf) => (
+        <QuoteRow
+          key={`${dtf.chainId}-${dtf.address}`}
+          dtf={dtf}
+          input={inputs[dtf.chainId]}
+          tokenInPrice={prices[dtf.chainId] ?? null}
+          {...rowProps}
+        />
+      ))}
+    </TableBody>
+  </Table>
+)
+
+export default QuotesTable

--- a/demo/components/quotes-table.tsx
+++ b/demo/components/quotes-table.tsx
@@ -48,6 +48,11 @@ export type QuotesTableProps = {
    */
   account?: Address
   /**
+   * Reports the chain's zapper spender as soon as a quote reveals it, so the
+   * inputs can be approved without a per-row approve button.
+   */
+  onApprovalTarget: (chainId: number, approvalAddress: Address) => void
+  /**
    * Bumped by "Refresh now": part of every row's query key, so a click always
    * fetches a new round instead of re-serving the last one.
    */
@@ -108,6 +113,7 @@ const QuoteRow = ({
   forceMint,
   deepLiquidity,
   account,
+  onApprovalTarget,
   round,
   armed,
   autoRefreshMs,
@@ -176,6 +182,11 @@ const QuoteRow = ({
   })
 
   const result = query.data?.result
+  const approvalAddress = result?.approvalAddress
+
+  React.useEffect(() => {
+    if (approvalAddress) onApprovalTarget(dtf.chainId, approvalAddress)
+  }, [approvalAddress, dtf.chainId, onApprovalTarget])
 
   return (
     <TableRow>

--- a/demo/components/ui/table.tsx
+++ b/demo/components/ui/table.tsx
@@ -1,0 +1,80 @@
+import * as React from 'react'
+import { cn } from '../../lib/utils'
+
+const Table = React.forwardRef<
+  HTMLTableElement,
+  React.HTMLAttributes<HTMLTableElement>
+>(({ className, ...props }, ref) => (
+  <div className="relative w-full overflow-auto">
+    <table
+      ref={ref}
+      className={cn('w-full caption-bottom text-sm', className)}
+      {...props}
+    />
+  </div>
+))
+Table.displayName = 'Table'
+
+const TableHeader = React.forwardRef<
+  HTMLTableSectionElement,
+  React.HTMLAttributes<HTMLTableSectionElement>
+>(({ className, ...props }, ref) => (
+  <thead ref={ref} className={cn('[&_tr]:border-b', className)} {...props} />
+))
+TableHeader.displayName = 'TableHeader'
+
+const TableBody = React.forwardRef<
+  HTMLTableSectionElement,
+  React.HTMLAttributes<HTMLTableSectionElement>
+>(({ className, ...props }, ref) => (
+  <tbody
+    ref={ref}
+    className={cn('[&_tr:last-child]:border-0', className)}
+    {...props}
+  />
+))
+TableBody.displayName = 'TableBody'
+
+const TableRow = React.forwardRef<
+  HTMLTableRowElement,
+  React.HTMLAttributes<HTMLTableRowElement>
+>(({ className, ...props }, ref) => (
+  <tr
+    ref={ref}
+    className={cn(
+      'border-b border-border-secondary transition-colors hover:bg-secondary/50',
+      className
+    )}
+    {...props}
+  />
+))
+TableRow.displayName = 'TableRow'
+
+const TableHead = React.forwardRef<
+  HTMLTableCellElement,
+  React.ThHTMLAttributes<HTMLTableCellElement>
+>(({ className, ...props }, ref) => (
+  <th
+    ref={ref}
+    className={cn(
+      'h-10 whitespace-nowrap px-3 text-left align-middle text-xs font-medium text-muted-foreground',
+      className
+    )}
+    {...props}
+  />
+))
+TableHead.displayName = 'TableHead'
+
+const TableCell = React.forwardRef<
+  HTMLTableCellElement,
+  React.TdHTMLAttributes<HTMLTableCellElement>
+>(({ className, ...props }, ref) => (
+  <td
+    ref={ref}
+    className={cn('whitespace-nowrap px-3 py-2 align-middle', className)}
+    {...props}
+  />
+))
+TableCell.displayName = 'TableCell'
+
+export { Table, TableHeader, TableBody, TableRow, TableHead, TableCell }

--- a/demo/lib/dtf-discover.ts
+++ b/demo/lib/dtf-discover.ts
@@ -1,0 +1,37 @@
+import { useQuery } from '@tanstack/react-query'
+import { Address } from 'viem'
+import { AvailableChain } from '@/utils/chains'
+
+export type DiscoverDTF = {
+  address: Address
+  name: string
+  symbol: string
+  price: number
+  marketCap: number
+  chainId: AvailableChain
+  type: 'index' | 'yield'
+  status: 'active' | 'deprecated' | 'unsupported'
+}
+
+// Same list the app's discover page is built from. Index DTFs only: the zapper
+// widget is an Index DTF surface (yield DTFs use the legacy zap v2 flow).
+export const useDiscoverDTFs = (
+  apiUrl: string,
+  { includeDeprecated }: { includeDeprecated: boolean }
+) =>
+  useQuery({
+    queryKey: ['discover-dtfs', apiUrl, includeDeprecated],
+    queryFn: async (): Promise<DiscoverDTF[]> => {
+      const response = await fetch(`${apiUrl}discover/dtfs`)
+      if (!response.ok) {
+        throw new Error(`Failed to fetch DTFs: ${response.status}`)
+      }
+      const data: DiscoverDTF[] = await response.json()
+      return data
+        .filter((dtf) => dtf.type === 'index')
+        .filter((dtf) => includeDeprecated || dtf.status === 'active')
+        .sort((a, b) => b.marketCap - a.marketCap)
+    },
+    refetchInterval: 1000 * 60 * 10,
+    staleTime: 1000 * 60,
+  })

--- a/demo/lib/zap-quote.ts
+++ b/demo/lib/zap-quote.ts
@@ -1,0 +1,136 @@
+import { Address, formatUnits } from 'viem'
+import zapper, { ZapResponse, ZapResult } from '@/types/api'
+import { PLACEHOLDER_SIGNER } from '@/utils/constants'
+
+/**
+ * Only the native zap provider (the ZRS services) is quoted here: the
+ * aggregator/RFQ sources don't exercise the zapper itself, and quoting every
+ * source for every DTF on a refresh interval would hit their rate limits.
+ */
+export const QUOTE_SOURCE = 'zap' as const
+
+/** Folio (DTF) tokens are always 18 decimals. */
+export const DTF_DECIMALS = 18
+
+// Rounds are queued so a refresh cycle can never fan out one request per DTF
+// at once (~20+ DTFs today).
+const MAX_CONCURRENT_QUOTES = 4
+
+let running = 0
+const waiting: (() => void)[] = []
+
+const acquire = () =>
+  new Promise<void>((resolve) => {
+    if (running < MAX_CONCURRENT_QUOTES) {
+      running++
+      resolve()
+      return
+    }
+    waiting.push(() => {
+      running++
+      resolve()
+    })
+  })
+
+const release = () => {
+  running--
+  waiting.shift()?.()
+}
+
+export type QuoteRequest = {
+  zapperApiUrl: string
+  chainId: number
+  tokenIn: Address
+  tokenInDecimals: number
+  tokenInPrice: number | null
+  amountIn: string
+  tokenOut: Address
+  tokenOutPrice: number | null
+  slippage: number
+  forceMint: boolean
+  deepLiquidity: boolean
+}
+
+export type QuoteRow = {
+  result: ZapResult
+  endpoint: string
+  durationMs: number
+}
+
+/**
+ * Values both sides of the quote from Reserve prices (input token price and the
+ * DTF's own price), the same way the widget does — provider values only stand
+ * in when a Reserve price is missing.
+ */
+const priceQuote = (result: ZapResult, request: QuoteRequest): ZapResult => {
+  const { tokenInPrice, tokenInDecimals, tokenOutPrice } = request
+  const amountInValue =
+    tokenInPrice != null
+      ? tokenInPrice *
+        Number(formatUnits(BigInt(result.amountIn || 0), tokenInDecimals))
+      : result.amountInValue
+  const amountOutValue =
+    tokenOutPrice != null
+      ? tokenOutPrice *
+        Number(formatUnits(BigInt(result.amountOut || 0), DTF_DECIMALS))
+      : result.amountOutValue
+
+  const bothPriced =
+    amountInValue != null && amountInValue > 0 && amountOutValue != null
+  if (!bothPriced) return { ...result, amountInValue, amountOutValue }
+
+  return {
+    ...result,
+    amountInValue,
+    amountOutValue,
+    priceImpact: ((amountInValue - amountOutValue) / amountInValue) * 100,
+    truePriceImpact:
+      ((amountInValue - amountOutValue - (result.dustValue ?? 0)) /
+        amountInValue) *
+      100,
+  }
+}
+
+export const buildZapEndpoint = (request: QuoteRequest): string =>
+  zapper.zap({
+    url: request.zapperApiUrl,
+    chainId: request.chainId,
+    tokenIn: request.tokenIn,
+    tokenOut: request.tokenOut,
+    amountIn: request.amountIn,
+    slippage: request.slippage,
+    signer: PLACEHOLDER_SIGNER,
+    trade: !request.forceMint,
+    deepLiquidity: request.deepLiquidity,
+  })
+
+/**
+ * Display-only mint quote: the placeholder signer keeps the response free of
+ * anything executable, so no wallet is needed to watch the table.
+ */
+export const fetchZapQuote = async (
+  request: QuoteRequest
+): Promise<QuoteRow> => {
+  const endpoint = buildZapEndpoint(request)
+
+  await acquire()
+  const startedAt = Date.now()
+  try {
+    const response = await fetch(endpoint)
+    // The zapper answers routing failures with an error body and a 4xx/5xx, so
+    // the body is read either way — it carries the actionable reason.
+    const data: ZapResponse | null = await response.json().catch(() => null)
+    if (data?.status === 'error' || !data?.result) {
+      throw new Error(
+        data?.error || `zap error: ${response.status} ${response.statusText}`
+      )
+    }
+    return {
+      result: priceQuote(data.result, request),
+      endpoint,
+      durationMs: Date.now() - startedAt,
+    }
+  } finally {
+    release()
+  }
+}

--- a/demo/lib/zap-quote.ts
+++ b/demo/lib/zap-quote.ts
@@ -1,6 +1,10 @@
 import { Address, formatUnits } from 'viem'
 import zapper, { ZapResponse, ZapResult } from '@/types/api'
-import { PLACEHOLDER_SIGNER } from '@/utils/constants'
+import {
+  classifyEstimateGasError,
+  SIMULATION_TIMEOUT_MS,
+  SimulationTimeoutError,
+} from '@/hooks/zap-quote-simulation'
 
 /**
  * Only the native zap provider (the ZRS services) is quoted here: the
@@ -49,12 +53,28 @@ export type QuoteRequest = {
   slippage: number
   forceMint: boolean
   deepLiquidity: boolean
+  /**
+   * The connected wallet when there is one, otherwise the placeholder signer.
+   * A real signer is what makes the response executable (`tx`, real `gas`,
+   * `approvalNeeded`, `insufficientFunds`) and therefore simulatable.
+   */
+  signer: Address
 }
+
+export type Simulation =
+  | { status: 'ok' }
+  | { status: 'reverted'; error: string }
+  /** Nothing was proven about the quote — the reason says why. */
+  | { status: 'unverifiable'; reason: string }
+
+/** `estimateGas` against the quote's own tx; the wallet is never touched. */
+export type SimulateTx = (tx: NonNullable<ZapResult['tx']>) => Promise<void>
 
 export type QuoteRow = {
   result: ZapResult
   endpoint: string
   durationMs: number
+  simulation: Simulation | null
 }
 
 /**
@@ -91,6 +111,47 @@ const priceQuote = (result: ZapResult, request: QuoteRequest): ZapResult => {
   }
 }
 
+/**
+ * Single-quote flavour of `filterQuotesBySimulation`: the table wants to *show*
+ * why a row is unproven, not silently keep it, so the outcome is reported
+ * instead of collapsed into keep/drop.
+ */
+const simulateQuote = async (
+  result: ZapResult,
+  simulate: SimulateTx
+): Promise<Simulation> => {
+  if (!result.tx) return { status: 'unverifiable', reason: 'no transaction' }
+  // Without the approval in place the swap tx is guaranteed to revert, so the
+  // simulation would say nothing about the quote itself.
+  if (result.approvalNeeded) {
+    return { status: 'unverifiable', reason: 'approval needed' }
+  }
+  if (result.insufficientFunds) {
+    return { status: 'unverifiable', reason: 'insufficient balance' }
+  }
+
+  let timer: ReturnType<typeof setTimeout> | undefined
+  try {
+    const timeout = new Promise<never>((_, reject) => {
+      timer = setTimeout(
+        () => reject(new SimulationTimeoutError('simulation timed out')),
+        SIMULATION_TIMEOUT_MS
+      )
+    })
+    const run = simulate(result.tx)
+    run.catch(() => {})
+    await Promise.race([run, timeout])
+    return { status: 'ok' }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    return classifyEstimateGasError(error) === 'revert'
+      ? { status: 'reverted', error: message }
+      : { status: 'unverifiable', reason: message.split('\n')[0] }
+  } finally {
+    clearTimeout(timer)
+  }
+}
+
 export const buildZapEndpoint = (request: QuoteRequest): string =>
   zapper.zap({
     url: request.zapperApiUrl,
@@ -99,17 +160,20 @@ export const buildZapEndpoint = (request: QuoteRequest): string =>
     tokenOut: request.tokenOut,
     amountIn: request.amountIn,
     slippage: request.slippage,
-    signer: PLACEHOLDER_SIGNER,
+    signer: request.signer,
     trade: !request.forceMint,
     deepLiquidity: request.deepLiquidity,
   })
 
 /**
- * Display-only mint quote: the placeholder signer keeps the response free of
- * anything executable, so no wallet is needed to watch the table.
+ * Fetches one mint quote and, when a simulator is supplied (i.e. a wallet is
+ * connected), checks whether its transaction would actually go through.
+ * With the placeholder signer the response carries nothing executable, so the
+ * table works read-only with no wallet at all.
  */
 export const fetchZapQuote = async (
-  request: QuoteRequest
+  request: QuoteRequest,
+  simulate?: SimulateTx
 ): Promise<QuoteRow> => {
   const endpoint = buildZapEndpoint(request)
 
@@ -125,10 +189,12 @@ export const fetchZapQuote = async (
         data?.error || `zap error: ${response.status} ${response.statusText}`
       )
     }
+    const durationMs = Date.now() - startedAt
     return {
       result: priceQuote(data.result, request),
       endpoint,
-      durationMs: Date.now() - startedAt,
+      durationMs,
+      simulation: simulate ? await simulateQuote(data.result, simulate) : null,
     }
   } finally {
     release()

--- a/demo/quotes-main.tsx
+++ b/demo/quotes-main.tsx
@@ -2,19 +2,23 @@ import React from 'react'
 import ReactDOM from 'react-dom/client'
 import { WagmiProvider } from 'wagmi'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { RainbowKitProvider } from '@rainbow-me/rainbowkit'
+import '@rainbow-me/rainbowkit/styles.css'
 import { config } from './wagmi-config'
 import QuotesApp from './QuotesApp'
 import './index.css'
 
 const queryClient = new QueryClient()
 
-// No wallet UI here: quotes are display-only (placeholder signer), so the page
-// needs the wagmi/query providers the package expects and nothing else.
+// Wallet is optional: without one the table quotes with the placeholder signer
+// (display-only), with one it quotes for the real signer and simulates.
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
     <WagmiProvider config={config}>
       <QueryClientProvider client={queryClient}>
-        <QuotesApp />
+        <RainbowKitProvider>
+          <QuotesApp />
+        </RainbowKitProvider>
       </QueryClientProvider>
     </WagmiProvider>
   </React.StrictMode>

--- a/demo/quotes-main.tsx
+++ b/demo/quotes-main.tsx
@@ -1,0 +1,21 @@
+import React from 'react'
+import ReactDOM from 'react-dom/client'
+import { WagmiProvider } from 'wagmi'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { config } from './wagmi-config'
+import QuotesApp from './QuotesApp'
+import './index.css'
+
+const queryClient = new QueryClient()
+
+// No wallet UI here: quotes are display-only (placeholder signer), so the page
+// needs the wagmi/query providers the package expects and nothing else.
+ReactDOM.createRoot(document.getElementById('root')!).render(
+  <React.StrictMode>
+    <WagmiProvider config={config}>
+      <QueryClientProvider client={queryClient}>
+        <QuotesApp />
+      </QueryClientProvider>
+    </WagmiProvider>
+  </React.StrictMode>
+)

--- a/demo/quotes.html
+++ b/demo/quotes.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>React Zapper Quote Table</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/quotes-main.tsx"></script>
+  </body>
+</html>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -37,6 +37,13 @@ export default defineConfig(({ mode, command }) => {
       build: {
         outDir: '../dist-demo',
         emptyOutDir: true,
+        rollupOptions: {
+          // Two tools, two pages: the zapper demo and the quote table.
+          input: {
+            index: resolve(__dirname, 'demo/index.html'),
+            quotes: resolve(__dirname, 'demo/quotes.html'),
+          },
+        },
       },
       resolve: {
         alias: {


### PR DESCRIPTION
## Summary

A second page in the demo app (`/quotes.html`, linked from the demo header) that answers "what is the zapper quoting right now, for everything?" — one row per Index DTF instead of one DTF at a time. The demo build is now a 2-entry MPA (`demo/index.html` + `demo/quotes.html`), so it ships with the existing `pnpm build:demo` deploy; the zapper widget is not mounted here, so the package's module-level atoms stay untouched.

DTFs come from the discover endpoint, not a hardcoded list: `GET {apiUrl}discover/dtfs` → `type === 'index'`, active-only unless "Include Deprecated" is flipped, market-cap desc.

**Only the native zap provider is quoted** (per @akshatmittal on the request thread): aggregator/RFQ sources wouldn't tell us anything about the zapper and quoting all of them per DTF per interval would trip their rate limits. So instead of `fetchBestZapQuote`, each row issues one request built from the package's own URL builder, and values the trade the way the widget does:

```ts
// demo/lib/zap-quote.ts
const endpoint = zapper.zap({ url: zapperApiUrl, chainId, tokenIn, tokenOut, amountIn,
                              slippage, signer, trade: !forceMint, deepLiquidity })
// amountOutValue = dtf.price (discover) * amountOut ; amountInValue = reserve price * amountIn
// priceImpact / truePriceImpact recomputed from those, like applyReservePricing
```

**Wallet is optional, and it changes what the table can prove.** With no wallet, `signer = PLACEHOLDER_SIGNER` and the response carries nothing executable — display-only. Connect one (RainbowKit, same config as the demo) and rows are quoted for that signer, so `tx`/`gas`/`approvalNeeded` are real and each row's transaction is checked with `estimateGas`:

```ts
// per row, provider-agnostic — the wallet is never prompted, no zap is ever submitted
!result.tx                    -> unverifiable('no transaction')
result.approvalNeeded         -> unverifiable('approval needed')      // tx would revert regardless
result.insufficientFunds      -> unverifiable('insufficient balance')
estimateGas(...) throws       -> classifyEstimateGasError() === 'revert' ? reverted : unverifiable(reason)
```

The `reverted`/`unverifiable` split reuses the widget's own `classifyEstimateGasError` + `SIMULATION_TIMEOUT_MS`, but reports the reason instead of collapsing to keep/drop the way `filterQuotesBySimulation` does — on a monitoring surface "couldn't be checked, because approval" and "the zapper handed us a reverting tx" must not look alike.

Because an unapproved input makes *every* row on that chain unverifiable, approvals are a per-chain concern rather than a per-row button: **"Create approvals"** under the input selector approves the configured inputs for the zapper, at the widget's `amountIn * 120 / 100`, then invalidates `['dtf-zap-quote']` so Simulation moves off `approval needed`. The spender is not a constant anywhere in the package — it's `ZapResult.approvalAddress` — so rows report it upward as quotes reveal it (`onApprovalTarget`), which is the one precondition: a chain must have quoted once before it can be approved.

Also of note: the widget's Mixpanel-instrumented quote pipeline is bypassed — a monitoring page hammering `index-dtf-zap-*` events would pollute the funnel.

Request budget is the other design constraint:

- Nothing is quoted on page load. "Refresh now" bumps a `round` counter that is part of every row's query key (one round = one request per DTF); the dropdown beside it starts a 15s / 60s / 300s cadence and is **Off** by default.
- `fetchZapQuote` goes through a module-level semaphore (`MAX_CONCURRENT_QUOTES = 4`), so a cycle never fans out ~20 requests at once.

Options mirror the demo's (zapper endpoint incl. ZRS-1/2/3, Reserve API endpoint, slippage, force mint, deep liquidity) plus a **per-chain input** row (amount + token from `zappableTokens`, defaulting to the chain's stable) since the supported inputs differ per chain. Columns: output, output value, price impact, true price impact, dust, simulation, gas, latency, age, and a `raw` link to the quote URL — errors render the API's own `error` string (e.g. `swap planning failed: unknown output token`) rather than a bare status code, which is what makes the table useful for triage.

Verification note: quotes, gas and the simulation column were exercised against production ZRS-1 with a real signer (via a temporary local mock connector for a whale address — not part of the diff), which is where the `approval needed` screenshot below comes from. The approval transactions themselves were never sent, since that needs a funded wallet.

![quote table with a signer](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmdfeU5mMTM5RVE5WkpQNzZmeSIsInVzZXJfaWQiOm51bGwsImJ1Y2tldF9uYW1lIjoiZGV2aW5hdHRhY2htZW50cyIsImJ1Y2tldF9rZXkiOiJhdHRhY2htZW50c19wcml2YXRlL29yZ195TmYxMzlFUTlaSlA3NmZ5L2E1YWEzMzc2LTJkMjMtNDg2Yi1iYmFiLTNiMmM2YTU3YWM3YyIsImlhdCI6MTc4NjU3MDU2OCwiZXhwIjoxNzg3MTc1MzY4LCJmaWxlbmFtZSI6InEtc2ltLWNvbHVtbnMucG5nIn0.SR4WB5yjeqggZuyzD-49zGCkv9j11rMVxD7xWerqCWM)

![create approvals](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmdfeU5mMTM5RVE5WkpQNzZmeSIsInVzZXJfaWQiOm51bGwsImJ1Y2tldF9uYW1lIjoiZGV2aW5hdHRhY2htZW50cyIsImJ1Y2tldF9rZXkiOiJhdHRhY2htZW50c19wcml2YXRlL29yZ195TmYxMzlFUTlaSlA3NmZ5L2VjZjdiMTJiLTY5MDYtNGNmOS04YmM4LTMwNTljOWZhZWMyZiIsImlhdCI6MTc4NjU3MDU2OCwiZXhwIjoxNzg3MTc1MzY4LCJmaWxlbmFtZSI6InEtbW9jazIucG5nIn0.WNgoZ8BdktGoA0wf-Oql4MAdIPA0GQTlhb8_EcFYJl4)


Link to Devin session: https://app.devin.ai/sessions/437cc525c0f84733b83cd70d4083ff88
Requested by: @TheFrozenFire